### PR TITLE
ci: only validate on specific cases

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -2,7 +2,13 @@ name: Validate
 
 on:
   push:
+    branches:
+      - main
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
   pull_request:
+    branches:
+      - main
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:


### PR DESCRIPTION
We only need to validate on direct pushes to the main branch, tags, and PRs against the main branch.